### PR TITLE
fix:sync the token from localStorage to the store on load

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,10 +1,15 @@
 import { useAuthStore } from "~/stores/auth"
 
-export default defineNuxtRouteMiddleware(() => {
+export default defineNuxtRouteMiddleware((to, from) => {
     const auth = useAuthStore()
     if (!auth.token) {
         return navigateTo('/')
     }
+})
+
+onMounted(() => {
+    const auth = useAuthStore()
+    auth.initializeAuth()
 })
 
 

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -16,6 +16,12 @@ export const useAuthStore = defineStore('auth', {
             this.user = null
             this.token = null
             localStorage.removeItem('access_token')
+        },
+        initializeAuth() {
+            const storedToken = localStorage.getItem('access_token')
+            if (storedToken) {
+                this.token = storedToken
+            }
         }
     }
 })


### PR DESCRIPTION
Se agregó lógica para sincronizar el token del localStorage con el store de pinia porque al agregar el middleware para la protección de la ruta cuando el middleware se ejecutaba el store aun estaba vacio y no permitia la autenticacion.